### PR TITLE
[Release monitoring] dependencies update

### DIFF
--- a/configs/deps.yaml
+++ b/configs/deps.yaml
@@ -1,7 +1,28 @@
 tags:
   lemp:
+    lemp:
+      digest: sha256:bb90546b5937cd5495d9bbebd387f175d117fef66d546c7741589d0841a50bf9
+      version: 1.18.0-php-7.4.9
   llsmp:
+    llsmp:
+      digest: sha256:85dd9850d4021c1a8131206c98475dd692ffaab0b6f23f2ebb5bf2a340f92397
+      version: 5.4.9-php-7.4.9
   mysql:
+    mysql5:
+      digest: sha256:bbbaee267da03f86084d5543c00c43b4c7aa8b890629a12a62ab8521c3d70e70
+      version: 5.7.31
+    mysql8:
+      digest: sha256:571f4b4457d8a736e3e292e299248048e19b32620524cd49f5ff9bbef27b205a
+      version: 8.0.21
   nginxbalancer:
+    nginxbalancer:
+      digest: sha256:96fdbf83753ff881c54256f0d1fe19586c9c3e10588de5324da91f3eb1adfc84
+      version: 1.18.0
   nginxphp:
+    nginxphp:
+      digest: sha256:fe0cfae6ccdb9fa7f914a8f118e285d5eb89bf5a0b3f73367433dfe6de391d27
+      version: 1.18.0-php-7.4.9
   storage:
+    storage:
+      digest: sha256:d5e483bb656fa2abe006391852ce472e8bf94b000dad3afd54bfc28e662526f6
+      version: 2.0-7.7


### PR DESCRIPTION
This pull request includes the following changes: tags nginxphp 1.18.0-php-7.4.9, lemp 1.18.0-php-7.4.9, storage 2.0-7.7, llsmp 5.4.9-php-7.4.9, mysql5 5.7.31, mysql8 8.0.21, nginxbalancer 1.18.0.
Please review them and merge if needed.