### PR TITLE
Improve clarity for trial groups disabled features

### DIFF
--- a/wordpress/scripts/settings.js
+++ b/wordpress/scripts/settings.js
@@ -26,7 +26,7 @@ if (group.groupType == 'trial') {
       "cls": "warning",
       "height": 30,
       "hideLabel": true,
-      "markup": "Not available for " + group.groupType + " account. Please upgrade your account."
+      "markup": "The following advanced features are not available for " + group.groupType + " accounts. Please upgrade your account to access these features."
     })
  
     if (isLS.result == 0 || isLS.result == Response.PERMISSION_DENIED) {


### PR DESCRIPTION
The original warning text shown when user is in trial group is confusing. The proposed amendment makes it clear that it's (only) the advanced features blocked due to trial account status, not the ability to use the install package at all.

Changes from:
![image](https://user-images.githubusercontent.com/10818722/96110728-2caa1180-0ed8-11eb-84e5-39df4566f670.png)

To:
![image](https://user-images.githubusercontent.com/10818722/96110758-36337980-0ed8-11eb-8e79-ea85e04a1dc2.png)
