### PR TITLE
JE-55416   [Let's Encrypt]: fallbackToX1 doesn't work in JPS packages…

### DIFF
--- a/wordpress/manifest.jps
+++ b/wordpress/manifest.jps
@@ -169,7 +169,7 @@ actions:
       nodeGroup: cp
       skipEmail: true
       settings:
-        customDomains: ${globals.DOMAIN}
+        test: false
         fallbackToX1: true
         withExtIp: ${globals.isExtIP}
 


### PR DESCRIPTION
… when domain converted to punycode